### PR TITLE
Accept atoms for values in recipe conditions

### DIFF
--- a/src/cpx_web_management.erl
+++ b/src/cpx_web_management.erl
@@ -2978,7 +2978,9 @@ encode_recipe_conditions([{Prop, Comp, Val} | Tail], Acc) ->
 		Val when is_integer(Val) ->
 			Val;
 		Val when is_list(Val) ->
-			list_to_binary(Val)
+			list_to_binary(Val);
+		Val when is_atom(Val) ->
+			Val
 	end,
 	Jcond = {struct, [
 		{<<"property">>, encode_recipe_conditions_prop(Prop)},


### PR DESCRIPTION
If recipes with conditions on media type which have atom values are saved, they cause errors when being rendered by the cpx_web_management. Fixed support for them.
