### PR TITLE
Add get agents by profile id

### DIFF
--- a/src/agent_auth.erl
+++ b/src/agent_auth.erl
@@ -1259,7 +1259,7 @@ profile_test_() ->
 		?assertEqual({atomic, []}, mnesia:transaction(F))
 	end },
 	{"Get a profile", fun() ->
-		?assertEqual(undefined, get_profile("noexists")),
+		?assertEqual(undefined, get_profile("test profile")),
 		new_profile("test profile", [testskill]),
 		?assertEqual(#agent_profile{name = "test profile", id = "1", skills = [testskill]}, get_profile("test profile"))
 	end},


### PR DESCRIPTION
I'm planning to store the tuple {id, IdOfProfile} in the profile field of the agent to take advantage of this.

Hm, not exactly complete however. agent_auth:get_profile has ties to destroy_profile which uses get_agents(Profile).

I realized though, things might get messy if we can support both the id and the names of the profiles. I was wondering if we could solely use the 'id' as the key for the mnesia table, and refer to the profiles from the agent_auth records as such.
