### PR TITLE
Queue transfer

### DIFF
--- a/src/agent_dummy_connection.erl
+++ b/src/agent_dummy_connection.erl
@@ -147,7 +147,11 @@ init([Args]) ->
 			password = proplists:get_value(password, Args, ""),
 			profile = proplists:get_value(profile, Args, "Default"),
 			skills = proplists:get_value(skills, Args, [english, '_agent', '_node']),
-			endpointtype = {self(), persistent, proplists:get_value(endpoint_type, Args, sip_registration)},
+			endpointtype = case proplists:get_value(transient, Args) of
+				true ->
+					{undefined, transient, proplists:get_value(endpoint_type, Args, sip_registration)};
+				_ -> {self(), persistent, proplists:get_value(endpoint_type, Args, sip_registration)}
+			end,
 			endpointdata = proplists:get_value(endpoint_data, Args, Login)
 	},
 	{ok, Pid} = case proplists:get_value(remote_node, Args) of

--- a/src/agent_dummy_connection.erl
+++ b/src/agent_dummy_connection.erl
@@ -74,6 +74,7 @@
 -type(login_option() :: {'login', string()}).
 -type(password_option() :: {'password', string()}).
 -type(endpoint_type() :: {'endpoint_type', endpoints()}).
+-type(endpoint_transients() :: 'transient').
 -type(endpoint_data() :: {'endpoint_data', string()}).
 -type(id_option() :: {'id', string()}).
 -type(profile() :: {'profile', string()}).
@@ -91,6 +92,7 @@
 	login_option() |
 	password_option() |
 	endpoint_type() |
+	endpoint_transients() |
 	endpoint_data() |
 	id_option() |
 	profile() |

--- a/src/agent_dummy_connection.erl
+++ b/src/agent_dummy_connection.erl
@@ -147,7 +147,7 @@ init([Args]) ->
 			password = proplists:get_value(password, Args, ""),
 			profile = proplists:get_value(profile, Args, "Default"),
 			skills = proplists:get_value(skills, Args, [english, '_agent', '_node']),
-			endpointtype = proplists:get_value(endpoint_type, Args, sip_registration),
+			endpointtype = {self(), persistent, proplists:get_value(endpoint_type, Args, sip_registration)},
 			endpointdata = proplists:get_value(endpoint_data, Args, Login)
 	},
 	{ok, Pid} = case proplists:get_value(remote_node, Args) of
@@ -184,6 +184,8 @@ init([Args]) ->
 		life_watch = Lifewatch,
 		release_data = Release_data}}.
 
+handle_call({agent_state, ringing, InCall}, {Apid, _Ref}, #state{agent_fsm = Apid} = State) ->
+	{reply, ok, State};
 handle_call(Request, _From, State) ->
 	{reply, {unknown_call, Request}, State}.
 


### PR DESCRIPTION
Change for OpenACD v1 - The change fixes agent's limbo state after doing queue_transfer. Transient agent's leg was not disconnected so OpenACD cannot route further calls to this agent anymore
