### PR TITLE
Fix spy and agent_transfer methods

### DIFF
--- a/src/agent.erl
+++ b/src/agent.erl
@@ -968,7 +968,7 @@ released({ringing, Call}, _From, #state{agent_rec = Agent} = State) ->
 	Newagent = Agent#agent{state=ringing, oldstate=released, statedata=Call, lastchange = util:now(), queuedrelease = Agent#agent.statedata},
 	set_cpx_monitor(Newagent, []),
 	{reply, ok, ringing, State#state{agent_rec = Newagent}};
-released({spy, Target}, {Conn, _Tag}, #state{agent_rec = #agent{connection = Conn} = _Agent} = State) ->
+released({spy, Target}, {Conn, _Tag}, #state{agent_rec = #agent{connection = Conn} = Agent} = State) ->
 	case self() of
 		Target ->
 			?INFO("Cannot spy on yourself", []),
@@ -977,7 +977,7 @@ released({spy, Target}, {Conn, _Tag}, #state{agent_rec = #agent{connection = Con
 			Out = case agent:dump_state(Target) of
 				#agent{state = Statename, statedata = Callrec} when Statename =:= oncall; Statename =:= outgoing ->
 					Self = self(),
-					gen_media:spy(Callrec#call.source, Self);
+					gen_media:spy(Callrec#call.source, Self, Agent);
 				_Else ->
 					invalid
 			end,

--- a/src/freeswitch_media.erl
+++ b/src/freeswitch_media.erl
@@ -359,7 +359,6 @@ handle_agent_transfer(AgentPid, Timeout, Call, State) ->
     case RingPid of 
         undefined ->
             %%% Transferee agent's ring leg is not created yet. Looping...
-            erlang:yield(),
             handle_agent_transfer(AgentPid, Timeout, Call, State);
         _Else ->
             {ok, [{"ivropt", State#state.ivroption}, {"caseid", State#state.caseid}], 

--- a/src/freeswitch_media.erl
+++ b/src/freeswitch_media.erl
@@ -223,10 +223,7 @@ handle_announce(Announcement, Callrec, State) ->
 handle_answer(Apid, Callrec, #state{xferchannel = XferChannel, xferuuid = XferUUID} = State) when is_pid(XferChannel) ->
 	link(XferChannel),
 	?INFO("intercepting ~s from channel ~s", [XferUUID, Callrec#call.id]),
-    %ok = fs_send_execute(State#state.cnode, Callrec#call.id, "set", "hangup_after_bridge=false"), 
     freeswitch:api(State#state.cnode, uuid_bridge, XferUUID ++ " " ++ Callrec#call.id),
-%	freeswitch:sendmsg(State#state.cnode, XferUUID,
-%		[{"call-command", "execute"}, {"execute-app-name", "intercept"}, {"execute-app-arg", Callrec#call.id}]),
 	case State#state.record_path of
 		undefined ->
 			ok;

--- a/src/gen_media.erl
+++ b/src/gen_media.erl
@@ -783,7 +783,7 @@ handle_call({'$gen_media_agent_transfer', {Agent, Apid}}, _From, #state{oncall_p
 	?NOTICE("Can't transfer to yourself, silly ~p! ~p", [Apid, Call#call.id]),
 	{reply, invalid, State};
 handle_call({'$gen_media_agent_transfer', {Agent, Apid}, Timeout}, _From, #state{callrec = Call, callback = Callback, ring_pid = undefined, oncall_pid = {OcAgent, Ocpid}, monitors = Mons, url_pop_getvars = GenPopopts} = State) when is_pid(Ocpid) ->
-	?INFO("Agent transfer (outofband) to ~p for ~p", [Agent, Call#call.id]),
+	?INFO("Agent transfer to Agent ~p for Call ~p", [Agent, Call#call.id]),
 	case set_agent_state(Apid, [ringing, State#state.callrec]) of
 		ok ->
 			case Callback:handle_agent_transfer(Apid, Timeout, State#state.callrec, State#state.substate) of
@@ -950,10 +950,9 @@ handle_call('$gen_media_agent_oncall', _From, #state{ring_pid = {Ragent, Rpid}, 
 					kill_outband_ring(State),
 					cdr:oncall(State#state.callrec, Ragent),
 					timer:cancel(State#state.ringout),
-                    ?INFO("Wrapup agent ~p[~p]", [OcAgent, Ocpid]),
 					set_agent_state(Ocpid, [wrapup, State#state.callrec]),
 					cdr:wrapup(State#state.callrec, OcAgent),
-					Agent = agent_manager:find_by_pid(Rpid),
+					%Agent = agent_manager:find_by_pid(Rpid),
 					set_cpx_mon(State#state{substate = NewState, ringout = false, oncall_pid = {Ragent, Rpid}, ring_pid = undefined}, [{agent, Ragent}]),
 					erlang:demonitor(Mons#monitors.oncall_pid),
 					Newmons = #monitors{oncall_pid = Mons#monitors.ring_pid},


### PR DESCRIPTION
OpenACD v1 - These changes solve issues with spy and agent_transfrer methods. They used non-existing methods of various modules: gen_media and freeswitch_ring.
