### PR TITLE
disable ssl when prop value is false

### DIFF
--- a/src/agent_web_listener.erl
+++ b/src/agent_web_listener.erl
@@ -196,7 +196,6 @@ init(Options) ->
 			Mochi1
 	end,
 	MochiSslPid = case Ssl of
-		undefined -> undefined;
 		true ->
 			?DEBUG("Starting ssl on port ~p", [SslPort]),
 			{ok, Mochi2} = mochiweb_http:start([
@@ -210,6 +209,7 @@ init(Options) ->
 				]}
 			]),
 			Mochi2
+		_ -> undefined;
 	end,
 	case {MochiNormalPid, MochiSslPid} of
 		{undefined, undefined} ->

--- a/src/cpx_web_management.erl
+++ b/src/cpx_web_management.erl
@@ -129,8 +129,6 @@ start(Opts) ->
 		?MODULE:loop(Req, NewOpts)
 	end,
 	case proplists:get_value(ssl, Opts) of
-		undefined ->
-			mochiweb_http:start([{loop, F}, {name, ?MODULE}, {port, Port}]);
 		true ->
 			mochiweb_http:start([
 				{loop, F},
@@ -141,7 +139,9 @@ start(Opts) ->
 					{certfile, util:get_certfile()},
 					{keyfile, util:get_keyfile()}
 				]}
-			])
+			]);
+		_ ->
+			mochiweb_http:start([{loop, F}, {name, ?MODULE}, {port, Port}])
 	end.
 
 -spec(start_link/0 :: () -> {'ok', pid()}).


### PR DESCRIPTION
It should avoid breaking when {ssl, false} is passed as an option.
