### PR TITLE
Load plug-in paths before starting cpx_supervisor

### DIFF
--- a/rel/files/openacd
+++ b/rel/files/openacd
@@ -19,10 +19,6 @@ PIPE_DIR=/tmp/$RUNNER_BASE_DIR/
 export OPENACD_LOG_DIR
 export OPENACD_RUN_DIR
 
-# Add plug-in dir to path
-ERL_LIBS=$ERL_LIBS:"$OPENACD_PLUGIN_DIR"
-export ERL_LIBS
-
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
     exec sudo -u $RUNNER_USER -i $0 $@

--- a/scripts/openacd
+++ b/scripts/openacd
@@ -16,7 +16,6 @@ OALIBDIR="$OADIR"/lib
 OABINDIR="$OADIR"/bin
 OAETCDIR="$ETCDIR"/openacd
 OAVARDIR="$VARDIR"/lib/openacd
-OAPLUGINDIR="$OADIR"/plugin.d
 OALOGDIR="$VARDIR"/log/openacd
 OADBDIR="$OAVARDIR"/db
 
@@ -36,8 +35,8 @@ fi
 # allow overriding vars from above
 [ -e "${OAETCDIR}/sysopenacd" ] && . "${OAETCDIR}/sysopenacd"
 
-# Add plug-in dir to path
-export ERL_LIBS=$ERL_LIBS:"$OALIBDIR":"$OAPLUGINDIR"
+# Add erlang paths
+export ERL_LIBS=$ERL_LIBS:"$OALIBDIR"
 
 # Extract the target node name from node.args
 NAME_ARG=`grep -e '-[s]*name' $OAETCDIR/vm.args`

--- a/src/cpx.erl
+++ b/src/cpx.erl
@@ -141,6 +141,8 @@ start(_Type, StartArgs) ->
 	mnesia:change_table_copy_type(schema, node(), disc_copies),
 	mnesia:set_master_nodes(lists:umerge(Nodes, [node()])),
 	merge_env(),
+
+	add_plugin_paths(),
 	try cpx_supervisor:start_link(Nodes) of
 		{ok, Pid} ->
 			application:set_env('OpenACD', uptime, util:now()),
@@ -1127,6 +1129,14 @@ start_plugin_app(Plugin) ->
 			Deps = proplists:get_value(applications, Keys),
 			start_plugin_apps(Deps),
 			StartFun()
+	end.
+
+add_plugin_paths() ->
+	case cpx:get_env(plugin_dir) of
+		{ok, Dir} ->
+			add_plugin_paths(Dir);
+		_ ->
+			ok
 	end.
 
 add_plugin_paths(PluginDir) ->


### PR DESCRIPTION
Paths to plug-ins are loaded before starting different managers. This is needed while providing a custom call_queue_config and agent_auth implementation c/o the plug-ins.
