### PR TITLE
Use symlink when loading plug-ins

### DIFF
--- a/src/cpx.erl
+++ b/src/cpx.erl
@@ -334,7 +334,7 @@ load_plugin(Plugin) ->
 				non_existing ->
 					{error, appfile_noexist};
 				Appfile ->
-					case file:make_link(Appfile, filename:join(PluginDir, atom_to_list(Plugin) ++ ".app")) of
+					case file:make_symlink(Appfile, filename:join(PluginDir, atom_to_list(Plugin) ++ ".app")) of
 						ok ->
 							{ok, Plugins} = cpx:get_env(plugins, []),
 							application:set_env('OpenACD', plugins, lists:usort([Plugin | Plugins])),


### PR DESCRIPTION
This should avoid the exdev error when the plug-in folder is in another filesystem (e.g. mounts).
