### PR TITLE
Voicemail fixes for v2

### DIFF
--- a/include_apps/oacd_dummy/src/dummy_media.erl
+++ b/include_apps/oacd_dummy/src/dummy_media.erl
@@ -82,7 +82,7 @@
 	prepare_endpoint/2,
 	handle_ring/4, 
 	handle_answer/5, 
-	handle_voicemail/3, 
+	handle_voicemail/4,
 	handle_announce/3, 
 	handle_ring_stop/4,
 	handle_agent_transfer/4,
@@ -558,8 +558,8 @@ handle_ring(_Agent, _RingData, _Call, #state{fail = Fail} = State) ->
 			{invalid, State#state{fail = Newfail}}
 	end.
 
--spec(handle_voicemail/3 :: (Whatever :: any(), Callrec :: #call{}, State :: #state{}) -> {'ok', #state{}} | {'invalid', #state{}}).
-handle_voicemail(_Whatever, _Callrec, #state{fail = Fail} = State) ->
+-spec(handle_voicemail/4 :: (Whatever :: any(), Callrec :: #call{}, Internal :: any(), State :: #state{}) -> {'ok', #state{}} | {'invalid', #state{}}).
+handle_voicemail(_Whatever, _Callrec, _Internal, #state{fail = Fail} = State) ->
 	case dict:fetch(voicemail, Fail) of
 		fail_once ->
 			Newfail = dict:store(voicemail, success, Fail),
@@ -777,14 +777,14 @@ dummy_test_() ->
 			"Answer voicemail call when set to success",
 			fun() ->
 				{ok, {State, _Call}} = init([[{queues, none}], success]),
-				?assertMatch({ok, State}, handle_voicemail("doesn't matter", "doesn't matter", State))
+				?assertMatch({ok, State}, handle_voicemail("doesn't matter", "doesn't matter", "doesn't matter", State))
 			end
 		},
 		{
 			"Answer voicemail call when set to fail",
 			fun() ->
 				{ok, {State, _Call}} = init([[{queues, none}], failure]),
-				?assertMatch({invalid, State}, handle_voicemail("doesn't matter", "doesn't matter", State))
+				?assertMatch({invalid, State}, handle_voicemail("doesn't matter", "doesn't matter", "doesn't matter", State))
 			end
 		},
 		{

--- a/include_apps/oacd_freeswitch/src/freeswitch_media.erl
+++ b/include_apps/oacd_freeswitch/src/freeswitch_media.erl
@@ -72,7 +72,7 @@
 	handle_ring/4,
 	handle_ring_stop/4,
 	handle_answer/5,
-	handle_voicemail/3,
+	handle_voicemail/4,
 	handle_spy/3,
 	handle_announce/3,
 %% TODO added for testing only (implemented with focus on real Calls - no other media)
@@ -334,11 +334,11 @@ handle_ring_stop(StateName, Callrec, _GenMedia, State) ->
 	{ok, State#state{statename = NewStatename, ringchannel=undefined}}.
 
 %% @hidden
--spec(handle_voicemail/3 :: (Agent :: pid() | 'undefined', Call :: #call{}, State :: #state{}) -> {'ok', #state{}}).
-handle_voicemail(Agent, Callrec, State) when is_pid(Agent) ->
-	{ok, Midstate} = handle_ring_stop(undefined, Callrec, undefined, State),
-	handle_voicemail(undefined, Callrec, Midstate);
-handle_voicemail(undefined, Call, State) ->
+-spec(handle_voicemail/4 :: (StateName :: atom(), Call :: #call{}, Internal :: any(), State :: #state{}) -> {'ok', #state{}}).
+handle_voicemail(inqueue_ringing, Callrec, Internal, State) ->
+	{ok, Midstate} = handle_ring_stop(inqueue_ringing, Callrec, undefined, State),
+	handle_voicemail(undefined, Callrec, Internal, Midstate);
+handle_voicemail(_, Call, _, State) ->
 	UUID = Call#call.id,
 	freeswitch:bgapi(State#state.cnode, uuid_transfer, UUID ++ " 'playback:IVR/prrec.wav,gentones:%(500\\,0\\,500),sleep:600,record:/tmp/${uuid}.wav' inline"),
 	{ok, State#state{statename = inivr, voicemail = "/tmp/"++UUID++".wav"}}.

--- a/include_apps/oacd_freeswitch/src/freeswitch_voicemail.erl
+++ b/include_apps/oacd_freeswitch/src/freeswitch_voicemail.erl
@@ -138,7 +138,7 @@ prepare_endpoint(Agent,Options) ->
 handle_answer(Apid, oncall_ringing, Callrec, _GenMediaState, #state{file=File, xferchannel = XferChannel} = State) when is_pid(XferChannel) ->
 	link(XferChannel),
 	%freeswitch_ring:hangup(State#state.ringchannel),
-	agent:conn_cast(Apid, {mediaload, Callrec, [{<<"width">>, <<"300px">>},{<<"height">>, <<"180px">>},{<<"title">>,<<>>}]}),
+	agent_channel:media_push(Apid, Callrec, {mediaload, Callrec, [{<<"width">>, <<"300px">>},{<<"height">>, <<"180px">>},{<<"title">>,<<>>}]}),
 	?NOTICE("Voicemail ~s successfully transferred! Time to play ~s", [Callrec#call.id, File]),
 	freeswitch:sendmsg(State#state.cnode, State#state.xferuuid,
 		[{"call-command", "execute"},
@@ -155,7 +155,7 @@ handle_answer(Apid, oncall_ringing, Callrec, _GenMediaState, #state{file=File, x
 
 handle_answer(Apid, inqueue_ringing, Callrec, _GenMediaState, #state{file=File} = State) ->
 	?NOTICE("Voicemail ~s successfully answered! Time to play ~s", [Callrec#call.id, File]),
-	agent:conn_cast(Apid, {mediaload, Callrec, [{<<"width">>, <<"300px">>},{<<"height">>, <<"180px">>},{<<"title">>,<<>>}]}),
+	agent_channel:media_push(Apid, Callrec, {mediaload, Callrec, [{<<"width">>, <<"300px">>},{<<"height">>, <<"180px">>},{<<"title">>,<<>>}]}),
 	freeswitch:sendmsg(State#state.cnode, State#state.ringuuid,
 		[{"call-command", "execute"},
 			{"event-lock", "true"},

--- a/src/gen_media.erl
+++ b/src/gen_media.erl
@@ -812,7 +812,7 @@ inqueue({{'$gen_media', announce}, Announce}, _From, {#base_state{
 	end,
 	{reply, ok, inqueue, {BaseState#base_state{substate = Substate}, Internal}};
 
-inqueue({{'$gen_meida', voicemail}, undefined}, _From, {BaseState, Internal}) ->
+inqueue({{'$gen_media', voicemail}, undefined}, _From, {BaseState, Internal}) ->
 	#base_state{callback = Callback, callrec = Call} = BaseState,
 	?INFO("trying to send media ~p to voicemail", [Call#call.id]),
 	case erlang:function_exported(Callback, handle_voicemail, 3) of

--- a/src/gen_media.erl
+++ b/src/gen_media.erl
@@ -710,6 +710,7 @@ init([Callback, Args]) ->
 					{Queue, Else}
 			end,
 			InqState = #inqueue_state{
+				queue_pid = {Queue, Qpid},
 				queue_mon = erlang:monitor(process, Qpid)
 			},
 			{ok, inqueue, {BaseState, InqState}};

--- a/src/gen_media.erl
+++ b/src/gen_media.erl
@@ -475,7 +475,7 @@ behaviour_info(callbacks) ->
 		{handle_ring, 4},
 		{handle_ring_stop, 4},
 		{handle_answer, 5}, 
-		%{handle_voicemail, 3}, 
+		%{handle_voicemail, 4},
 		%{handle_announce, 3}, 
 		{handle_agent_transfer, 4},
 		{handle_queue_transfer, 5},
@@ -816,7 +816,7 @@ inqueue({{'$gen_media', announce}, Announce}, _From, {#base_state{
 inqueue({{'$gen_media', voicemail}, undefined}, _From, {BaseState, Internal}) ->
 	#base_state{callback = Callback, callrec = Call} = BaseState,
 	?INFO("trying to send media ~p to voicemail", [Call#call.id]),
-	case erlang:function_exported(Callback, handle_voicemail, 3) of
+	case erlang:function_exported(Callback, handle_voicemail, 4) of
 		false ->
 			{reply, invalid, inqueue, {BaseState, Internal}};
 		true ->
@@ -941,7 +941,7 @@ inqueue_ringing({{'$gen_media', announce}, Announce}, _From, {BaseState, Interna
 inqueue_ringing({{'$gen_media', voicemail}, undefined}, _From, {BaseState, Internal}) ->
 	#base_state{callback = Callback, callrec = Call} = BaseState,
 	?INFO("trying to send media ~p to voicemail", [Call#call.id]),
-	case erlang:function_exported(Callback, handle_voicemail, 3) of
+	case erlang:function_exported(Callback, handle_voicemail, 4) of
 		false ->
 			{reply, invalid, inqueue_ringing, {BaseState, Internal}};
 		true ->


### PR DESCRIPTION
Some voicemail fixes for openacd v2. Voicemail now getting to the agent. Some problems still exist however.
- when agent is rang, then user transfers to voicemail, does not stop ringing on the agent's side.
- some data not displayed right on the web ui when receiving voicemail
