### PR TITLE
Enable supervisor dashboard

### DIFF
--- a/priv/www/agent/tabs/dashboard.html
+++ b/priv/www/agent/tabs/dashboard.html
@@ -99,7 +99,7 @@
     </div>
     <div dojoType="dijit.layout.ContentPane" splitter="true" region="center" id="dashboardAgentPane">
 		<table class="dashboard"><tbody id="agentDashboardTable">
-			<tr><th>Profile</th><th>Agents</th><th>Avail</th><th>In Call</th><th>Rel</th><th>Wra</th></tr>
+			<tr><th>Profile</th><th>Agents</th><th>Avail</th><!--th>In Call</th--><th>Rel</th><!--th>Wra</th--></tr>
 		</tbody></table>
     </div>
 </div>


### PR DESCRIPTION
Removed channel specific data for now. However, supervisor can only view count related to activity that has occurred while viewing the dashboard.

Any hints how the actual count (of agents logged in, released, etc) can be retrieved on startup of the agent dashboard?
